### PR TITLE
Unify candlestick styles in simple html

### DIFF
--- a/app/frontend/simple.html
+++ b/app/frontend/simple.html
@@ -60,14 +60,14 @@
     const addBtn = document.getElementById('add');
     const watchEl = document.getElementById('watch');
 
-    const state = { symbol: 'AAPL', timespan: '15m', window: 'max', chart: null, seriesPre: null, seriesReg: null, seriesPost: null, watch: JSON.parse(localStorage.getItem('simple.watch') || '[]') };
+    const state = { symbol: 'AAPL', timespan: '15m', window: 'max', chart: null, series: null, watch: JSON.parse(localStorage.getItem('simple.watch') || '[]') };
 
     function showError(text) {
       msg.textContent = text || '';
     }
 
     async function ensureChart() {
-      if (state.chart && state.seriesPre && state.seriesReg && state.seriesPost) return;
+      if (state.chart && state.series) return;
       if (!window.LightweightCharts || typeof window.LightweightCharts.createChart !== 'function') {
         throw new Error('Chart library failed to load.');
       }
@@ -80,14 +80,8 @@
       if (!state.chart || typeof state.chart.addCandlestickSeries !== 'function') {
         throw new Error('Chart API not ready.');
       }
-      state.seriesPre = state.chart.addCandlestickSeries({
-        upColor: '#60a5fa', downColor: '#60a5fa', borderUpColor: '#60a5fa', borderDownColor: '#60a5fa', wickUpColor: '#60a5fa', wickDownColor: '#60a5fa'
-      });
-      state.seriesReg = state.chart.addCandlestickSeries({
+      state.series = state.chart.addCandlestickSeries({
         upColor: '#0ec07f', downColor: '#ff4d4f', borderDownColor: '#ff4d4f', borderUpColor: '#0ec07f', wickDownColor: '#ff4d4f', wickUpColor: '#0ec07f'
-      });
-      state.seriesPost = state.chart.addCandlestickSeries({
-        upColor: '#a78bfa', downColor: '#a78bfa', borderUpColor: '#a78bfa', borderDownColor: '#a78bfa', wickUpColor: '#a78bfa', wickDownColor: '#a78bfa'
       });
     }
 
@@ -102,19 +96,7 @@
       return (data.candles || []).map(c => ({ time: Math.floor(c.t / 1000), open: c.o, high: c.h, low: c.l, close: c.c, t: c.t }));
     }
 
-    function nyMinutes(ms) {
-      const opt = { hour: '2-digit', minute: '2-digit', timeZone: 'America/New_York', hour12: false };
-      const [hh, mm] = new Intl.DateTimeFormat('en-US', opt).format(new Date(ms)).split(':').map(Number);
-      return hh * 60 + mm;
-    }
 
-    function sessionOf(ms) {
-      const m = nyMinutes(ms);
-      if (m >= 570 && m <= 960) return 'reg'; // 09:30 - 16:00
-      if (m >= 240 && m < 570) return 'pre';  // 04:00 - 09:29
-      if (m > 960 && m <= 1200) return 'post'; // 16:01 - 20:00
-      return 'post';
-    }
 
     async function loadSymbol(symbol) {
       showError('');
@@ -122,15 +104,14 @@
         await ensureChart();
         const candles = await fetchCandles(symbol);
         if (!candles.length) throw new Error('No candles returned.');
-        const pre = [], reg = [], post = [];
-        for (const c of candles) {
-          const item = { time: c.time, open: c.open, high: c.high, low: c.low, close: c.close };
-          const sess = sessionOf(c.t);
-          if (sess === 'reg') reg.push(item); else if (sess === 'pre') pre.push(item); else post.push(item);
-        }
-        state.seriesPre.setData(pre);
-        state.seriesReg.setData(reg);
-        state.seriesPost.setData(post);
+        const allCandles = candles.map(c => ({ 
+          time: c.time, 
+          open: c.open, 
+          high: c.high, 
+          low: c.low, 
+          close: c.close 
+        }));
+        state.series.setData(allCandles);
         state.symbol = symbol.toUpperCase();
         title.textContent = `${state.symbol} • ${state.timespan}`;
         renderWatch();


### PR DESCRIPTION
Remove distinct pre-market and post-market candle styles to display a single uniform candlestick series.

---
<a href="https://cursor.com/background-agent?bcId=bc-f5a0321f-b209-4f99-b0be-e0804990b0d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f5a0321f-b209-4f99-b0be-e0804990b0d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

